### PR TITLE
hotfix: someone mentioned this wasn't working 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linkk"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 readme = "README.md"
 authors = ["jer <alphastrata@gmail.com>"]


### PR DESCRIPTION
- macro no-longer returns the structs, but a new() that can create them.